### PR TITLE
feat: add support for all asc/desc sorting order combinations

### DIFF
--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -25,7 +25,14 @@ defmodule Paginator.Config do
   @minimum_limit 1
   @maximum_limit 500
   @default_total_count_limit 10_000
-  @order_directions [:asc, :desc]
+  @order_directions [
+    :asc,
+    :asc_nulls_last,
+    :asc_nulls_first,
+    :desc,
+    :desc_nulls_first,
+    :desc_nulls_last
+  ]
 
   def new(opts \\ []) do
     %__MODULE__{

--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -4,6 +4,7 @@ defmodule Paginator.Ecto.Query do
   import Ecto.Query
 
   alias Paginator.Config
+  alias Paginator.Ecto.Query.DynamicFilterBuilder
 
   def paginate(queryable, config \\ [])
 
@@ -18,29 +19,11 @@ defmodule Paginator.Ecto.Query do
     paginate(queryable, config)
   end
 
-  defp get_operator(:asc, :before), do: :lt
-  defp get_operator(:desc, :before), do: :gt
-  defp get_operator(:asc, :after), do: :gt
-  defp get_operator(:desc, :after), do: :lt
-
-  defp get_operator(direction, _),
-    do: raise("Invalid sorting value :#{direction}, please use either :asc or :desc")
-
-  defp get_operator_for_field(cursor_fields, key, direction) do
-    {_, order} =
-      cursor_fields
-      |> Enum.find(fn {field_key, _order} ->
-        field_key == key
-      end)
-
-    get_operator(order, direction)
-  end
-
   # This clause is responsible for transforming legacy list cursors into map cursors
   defp filter_values(query, fields, values, cursor_direction) when is_list(values) do
     new_values =
       fields
-      |> Keyword.keys()
+      |> Enum.map(&elem(&1, 0))
       |> Enum.zip(values)
       |> Map.new()
 
@@ -48,44 +31,39 @@ defmodule Paginator.Ecto.Query do
   end
 
   defp filter_values(query, fields, values, cursor_direction) when is_map(values) do
-    sorts =
-      fields
-      |> Enum.map(fn {column, _order} -> {column, Map.get(values, column)} end)
-      |> Enum.reject(fn val -> match?({_column, nil}, val) end)
+    filters = build_where_expression(query, fields, values, cursor_direction)
 
-    dynamic_sorts =
-      sorts
-      |> Enum.with_index()
-      |> Enum.reduce(true, fn {{bound_column, value}, i}, dynamic_sorts ->
-        {position, column} = column_position(query, bound_column)
+    where(query, [{q, 0}], ^filters)
+  end
 
-        dynamic = true
+  defp build_where_expression(query, [{column, order}], values, cursor_direction) do
+    value = Map.get(values, column)
+    {q_position, q_binding} = column_position(query, column)
 
-        dynamic =
-          case get_operator_for_field(fields, bound_column, cursor_direction) do
-            :lt ->
-              dynamic([{q, position}], field(q, ^column) < ^value and ^dynamic)
+    DynamicFilterBuilder.build!(%{
+      sort_order: order,
+      direction: cursor_direction,
+      value: value,
+      entity_position: q_position,
+      column: q_binding,
+      next_filters: true
+    })
+  end
 
-            :gt ->
-              dynamic([{q, position}], field(q, ^column) > ^value and ^dynamic)
-          end
+  defp build_where_expression(query, [{column, order} | fields], values, cursor_direction) do
+    value = Map.get(values, column)
+    {q_position, q_binding} = column_position(query, column)
 
-        dynamic =
-          sorts
-          |> Enum.take(i)
-          |> Enum.reduce(dynamic, fn {prev_column, prev_value}, dynamic ->
-            {position, prev_column} = column_position(query, prev_column)
-            dynamic([{q, position}], field(q, ^prev_column) == ^prev_value and ^dynamic)
-          end)
+    filters = build_where_expression(query, fields, values, cursor_direction)
 
-        if i == 0 do
-          dynamic([{q, position}], ^dynamic and ^dynamic_sorts)
-        else
-          dynamic([{q, position}], ^dynamic or ^dynamic_sorts)
-        end
-      end)
-
-    where(query, [{q, 0}], ^dynamic_sorts)
+    DynamicFilterBuilder.build!(%{
+      sort_order: order,
+      direction: cursor_direction,
+      value: value,
+      entity_position: q_position,
+      column: q_binding,
+      next_filters: filters
+    })
   end
 
   defp maybe_where(query, %Config{
@@ -160,7 +138,11 @@ defmodule Paginator.Ecto.Query do
             | expr:
                 Enum.map(expr, fn
                   {:desc, ast} -> {:asc, ast}
+                  {:desc_nulls_first, ast} -> {:asc_nulls_last, ast}
+                  {:desc_nulls_last, ast} -> {:asc_nulls_first, ast}
                   {:asc, ast} -> {:desc, ast}
+                  {:asc_nulls_last, ast} -> {:desc_nulls_first, ast}
+                  {:asc_nulls_first, ast} -> {:desc_nulls_last, ast}
                 end)
           }
         end

--- a/lib/paginator/ecto/query/asc_nulls_first.ex
+++ b/lib/paginator/ecto/query/asc_nulls_first.ex
@@ -1,0 +1,60 @@
+defmodule Paginator.Ecto.Query.AscNullsFirst do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value
+    )
+  end
+
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) < ^args.value or is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value or
+        is_nil(field(query, ^args.column))
+    )
+  end
+end

--- a/lib/paginator/ecto/query/asc_nulls_last.ex
+++ b/lib/paginator/ecto/query/asc_nulls_last.ex
@@ -1,0 +1,57 @@
+defmodule Paginator.Ecto.Query.AscNullsLast do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value or is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value or
+        is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic([{query, args.entity_position}], field(query, ^args.column) < ^args.value)
+  end
+
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value
+    )
+  end
+end

--- a/lib/paginator/ecto/query/desc_nulls_first.ex
+++ b/lib/paginator/ecto/query/desc_nulls_first.ex
@@ -1,0 +1,57 @@
+defmodule Paginator.Ecto.Query.DescNullsFirst do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value or is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value or
+        is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic([{query, args.entity_position}], field(query, ^args.column) < ^args.value)
+  end
+
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value
+    )
+  end
+end

--- a/lib/paginator/ecto/query/desc_nulls_last.ex
+++ b/lib/paginator/ecto/query/desc_nulls_last.ex
@@ -1,0 +1,60 @@
+defmodule Paginator.Ecto.Query.DescNullsLast do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value
+    )
+  end
+
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) < ^args.value or is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value or
+        is_nil(field(query, ^args.column))
+    )
+  end
+end

--- a/lib/paginator/ecto/query/dynamic_filter_builder.ex
+++ b/lib/paginator/ecto/query/dynamic_filter_builder.ex
@@ -1,0 +1,51 @@
+defmodule Paginator.Ecto.Query.DynamicFilterBuilder do
+  @dispatch_table %{
+    desc: Paginator.Ecto.Query.DescNullsFirst,
+    desc_nulls_first: Paginator.Ecto.Query.DescNullsFirst,
+    desc_nulls_last: Paginator.Ecto.Query.DescNullsLast,
+    asc: Paginator.Ecto.Query.AscNullsLast,
+    asc_nulls_last: Paginator.Ecto.Query.AscNullsLast,
+    asc_nulls_first: Paginator.Ecto.Query.AscNullsFirst
+  }
+
+  @callback build_dynamic_filter(%{
+              direction: :after | :before,
+              entity_position: integer(),
+              column: term(),
+              value: term(),
+              next_filters: Ecto.Query.t()
+            }) :: Ecto.Query.t()
+
+  @type sort_order ::
+          :asc
+          | :asc_nulls_first
+          | :asc_nulls_desc
+          | :desc
+          | :desc_nulls_first
+          | :desc_nulls_last
+
+  @type direction :: :after | :before
+
+  @spec build!(%{
+          sort_order: sort_order(),
+          direction: direction(),
+          entity_position: integer(),
+          column: term(),
+          value: term(),
+          next_filters: Ecto.Query.t()
+        }) :: Ecto.Query.t()
+  def build!(input) do
+    case Map.fetch(@dispatch_table, input.sort_order) do
+      {:ok, module} ->
+        apply(module, :build_dynamic_filter, [input])
+
+      :error ->
+        direction = input.direction
+        available_sort_orders = Map.keys(@dispatch_table) |> Enum.join(", ")
+
+        raise(
+          "Invalid sorting value :#{direction}, please please use either #{available_sort_orders}"
+        )
+    end
+  end
+end

--- a/test/paginator_test.exs
+++ b/test/paginator_test.exs
@@ -702,7 +702,7 @@ defmodule PaginatorTest do
         |> Repo.paginate(
           cursor_fields: [:charged_at, :id],
           sort_direction: :desc,
-          after: encode_cursor(%{charged_at: nil, id: nil}),
+          after: encode_cursor(%{charged_at: nil, id: -1}),
           limit: 8
         )
 
@@ -936,6 +936,85 @@ defmodule PaginatorTest do
            }
   end
 
+  @available_sorting_order [
+    :asc,
+    :asc_nulls_last,
+    :asc_nulls_first,
+    :desc,
+    :desc_nulls_first,
+    :desc_nulls_last
+  ]
+
+  for order <- @available_sorting_order do
+    test "throw an error if nulls are used in the last term - order_by charged_at #{order}" do
+      customer = insert(:customer)
+      insert(:payment, customer: customer, charged_at: NaiveDateTime.utc_now())
+      insert(:payment, customer: customer, charged_at: nil)
+      insert(:payment, customer: customer, charged_at: nil)
+
+      opts = [
+        cursor_fields: [charged_at: unquote(order)],
+        limit: 1
+      ]
+
+      query =
+        from(
+          p in Payment,
+          where: p.customer_id == ^customer.id,
+          order_by: [{^unquote(order), p.charged_at}],
+          select: p
+        )
+
+      assert_raise RuntimeError, fn -> paginate_as_list(query, opts) end
+    end
+  end
+
+  for field0_order <- @available_sorting_order, field1_order <- @available_sorting_order do
+    test "paginates correctly when pages contains nulls - order by charged_at #{field0_order}, id #{
+           field1_order
+         }" do
+      customer = insert(:customer)
+
+      now = NaiveDateTime.utc_now()
+
+      for k <- 1..50 do
+        if Enum.random([true, false]) do
+          if Enum.random([true, false]) do
+            insert(:payment, customer: customer, charged_at: NaiveDateTime.add(now, k))
+          else
+            insert(:payment, customer: customer, charged_at: NaiveDateTime.add(now, k - 1))
+          end
+        else
+          insert(:payment, customer: customer, charged_at: nil)
+        end
+      end
+
+      opts = [
+        cursor_fields: [charged_at: unquote(field0_order), id: unquote(field1_order)],
+        limit: 1
+      ]
+
+      query =
+        from(
+          p in Payment,
+          where: p.customer_id == ^customer.id,
+          order_by: [{^unquote(field0_order), p.charged_at}, {^unquote(field1_order), p.id}],
+          select: p
+        )
+
+      expected =
+        query
+        |> Repo.all(opts)
+        |> to_ids()
+
+      after_pagination = paginate_as_list(query, opts)
+      assert after_pagination == expected
+
+      before_pagination = paginate_before_as_list(query, opts)
+      assert before_pagination == init([nil | expected])
+    end
+  end
+
   defp to_ids(entries), do: Enum.map(entries, & &1.id)
 
   defp create_customers_and_payments(_context) do
@@ -1049,5 +1128,50 @@ defmodule PaginatorTest do
 
   defp days_ago(days) do
     DT.add!(DateTime.utc_now(), -(days * 86400))
+  end
+
+  defp paginate_as_list(query, opts, mapf \\ &to_ids(&1.entries)) do
+    opts
+    |> Stream.unfold(fn
+      nil ->
+        nil
+
+      opts ->
+        page = Repo.paginate(query, opts)
+
+        if after_value = page.metadata.after do
+          {mapf.(page), Keyword.put(opts, :after, after_value)}
+        else
+          {mapf.(page), nil}
+        end
+    end)
+    |> Stream.flat_map(&Function.identity/1)
+    |> Enum.to_list()
+  end
+
+  defp paginate_before_as_list(query, opts) do
+    query
+    |> paginate_as_list(opts, &[&1.metadata.before])
+    |> Enum.flat_map(fn
+      nil ->
+        [nil]
+
+      before_cursor ->
+        Repo.paginate(query, Keyword.put(opts, :before, before_cursor))
+        |> Map.fetch!(:entries)
+        |> to_ids
+    end)
+  end
+
+  defp init([]) do
+    []
+  end
+
+  defp init([_]) do
+    []
+  end
+
+  defp init([x | xs]) do
+    [x | init(xs)]
   end
 end


### PR DESCRIPTION
This patch adds support for all supported sorting orders when the
field is nullable. It is now possible to specify the following extra
sort orders in the cursor_fields:

  * asc_nulls_last, asc_nulls_first
  * desc_nulls_last, desc_nulls_first

As the number of different combinations is large, we refactored the
code that builds the dynamic filter expressions to make it a bit more
manageable. Each sorting order is now a separate module.

There is at least one problem with the current implementation
though. The `:asc/:desc` default order, w.r.t. to null values may vary
from vendor to vendor. For instance, we are following Postgres
defaults. It means that `:asc = :asc_nulls_last` and `:desc =
:desc_nulls_first`. However, if you are using Mysql instead, you get
`:asc = :asc_nulls_first` and `:desc = :desc_nulls_last`. Somehow we
need to factor in the adapter. However, I was not sure the best way to
achieve that, I opted for lefting it out for now and instead asks for
directions on that regard.